### PR TITLE
Update script with the new Dialog:shades{} widget and onclose Dialog event

### DIFF
--- a/Color Shading.lua
+++ b/Color Shading.lua
@@ -2,8 +2,6 @@
 -- Written by Dominick John, 2019
 -- https://github.com/alpineboarder/aseprite/
 
-local windowBounds = Rectangle(8, 8, 295, 295)
-
 function lerp(first, second, by)
   return first * (1 - by) + second * by
 end
@@ -30,7 +28,7 @@ function colorToInt(color)
 end
 
 function colorShift(color, hueShift, satShift, lightShift, shadeShift)
-  local newColor = color
+  local newColor = Color(color) -- Make a copy of the color so we don't modify the parameter
 
   -- SHIFT HUE
   newColor.hue = newColor.hue + hueShift * 359
@@ -57,7 +55,7 @@ function colorShift(color, hueShift, satShift, lightShift, shadeShift)
   local newShade = Color{red = newColor.red, green = newColor.green, blue = newColor.blue}
   local shadeInt = 0
   if (shadeShift >= 0)
-  then 
+  then
     newShade.hue = 50
     shadeInt = lerpRGBInt(colorToInt(newColor), colorToInt(newShade), shadeShift)
   elseif (shadeShift < 0)
@@ -73,182 +71,79 @@ function colorShift(color, hueShift, satShift, lightShift, shadeShift)
 end
 
 function showColors()
-  local dlg = Dialog("Color Shading")
-
-  -- Set the window size and position to be the same as last refresh (prevents window jumping)
-  local bounds = dlg.bounds
-  dlg.bounds = windowBounds
+  local dlg
+  dlg = Dialog{
+    title="Color Shading",
+    onclose=function()
+      ColorShadingWindowBounds = dlg.bounds
+    end
+  }
 
   -- CURRENT FOREGROUND COLOR
-  local currentColor = colorShift(app.fgColor, 0, 0, 0, 0)
+  local C = app.fgColor
 
   -- SHADING COLORS
-  local S1 = colorShift(app.fgColor, 0, 0.3, -0.6, -0.6)
-  local S2 = colorShift(app.fgColor, 0, 0.2, -0.2, -0.3)
-  local S3 = colorShift(app.fgColor, 0, 0.1, -0.1, -0.1)
-  local S5 = colorShift(app.fgColor, 0, 0.1, 0.1, 0.1)
-  local S6 = colorShift(app.fgColor, 0, 0.2, 0.2, 0.2)
-  local S7 = colorShift(app.fgColor, 0, 0.3, 0.5, 0.4)
+  local S1 = colorShift(C, 0, 0.3, -0.6, -0.6)
+  local S2 = colorShift(C, 0, 0.2, -0.2, -0.3)
+  local S3 = colorShift(C, 0, 0.1, -0.1, -0.1)
+  local S5 = colorShift(C, 0, 0.1, 0.1, 0.1)
+  local S6 = colorShift(C, 0, 0.2, 0.2, 0.2)
+  local S7 = colorShift(C, 0, 0.3, 0.5, 0.4)
 
   -- LIGHTNESS COLORS
-  local L1 = colorShift(app.fgColor, 0, 0, -0.4, 0)
-  local L2 = colorShift(app.fgColor, 0, 0, -0.2, 0)
-  local L3 = colorShift(app.fgColor, 0, 0, -0.1, 0)
-  local L5 = colorShift(app.fgColor, 0, 0, 0.1, 0)
-  local L6 = colorShift(app.fgColor, 0, 0, 0.2, 0)
-  local L7 = colorShift(app.fgColor, 0, 0, 0.4, 0)
+  local L1 = colorShift(C, 0, 0, -0.4, 0)
+  local L2 = colorShift(C, 0, 0, -0.2, 0)
+  local L3 = colorShift(C, 0, 0, -0.1, 0)
+  local L5 = colorShift(C, 0, 0, 0.1, 0)
+  local L6 = colorShift(C, 0, 0, 0.2, 0)
+  local L7 = colorShift(C, 0, 0, 0.4, 0)
 
   -- SATURATION COLORS
-  local C1 = colorShift(app.fgColor, 0, -0.5, 0, 0)
-  local C2 = colorShift(app.fgColor, 0, -0.2, 0, 0)
-  local C3 = colorShift(app.fgColor, 0, -0.1, 0, 0)
-  local C5 = colorShift(app.fgColor, 0, 0.1, 0, 0)
-  local C6 = colorShift(app.fgColor, 0, 0.2, 0, 0)
-  local C7 = colorShift(app.fgColor, 0, 0.5, 0, 0)
+  local C1 = colorShift(C, 0, -0.5, 0, 0)
+  local C2 = colorShift(C, 0, -0.2, 0, 0)
+  local C3 = colorShift(C, 0, -0.1, 0, 0)
+  local C5 = colorShift(C, 0, 0.1, 0, 0)
+  local C6 = colorShift(C, 0, 0.2, 0, 0)
+  local C7 = colorShift(C, 0, 0.5, 0, 0)
 
   -- HUE COLORS
-  local H1 = colorShift(app.fgColor, -0.15, 0, 0, 0)
-  local H2 = colorShift(app.fgColor, -0.1, 0, 0, 0)
-  local H3 = colorShift(app.fgColor, -0.05, 0, 0, 0)
-  local H5 = colorShift(app.fgColor, 0.05, 0, 0, 0)
-  local H6 = colorShift(app.fgColor, 0.1, 0, 0, 0)
-  local H7 = colorShift(app.fgColor, 0.15, 0, 0, 0)
+  local H1 = colorShift(C, -0.15, 0, 0, 0)
+  local H2 = colorShift(C, -0.1, 0, 0, 0)
+  local H3 = colorShift(C, -0.05, 0, 0, 0)
+  local H5 = colorShift(C, 0.05, 0, 0, 0)
+  local H6 = colorShift(C, 0.1, 0, 0, 0)
+  local H7 = colorShift(C, 0.15, 0, 0, 0)
 
   -- DIALOGUE
   dlg
-  :label{ text="Current Color" }
-  :color{ color = currentColor }
-  :button{ text="Get Current Color", onclick=function()
-    windowBounds = dlg.bounds
-    dlg:close()
-    showColors()
-    end }
+  :color{ label="Current Color", color=C }
+  :button{ text="Get",
+           onclick=function()
+             dlg:close()
+             showColors()
+           end }
 
   -- SHADING
-  :label { text="Shading" }
-  :color { color = S1 }
-  :color { color = S2 }
-  :color { color = S3 }
-  :color { color = currentColor }
-  :color { color = S5 }
-  :color { color = S6 }
-  :color { color = S7 }
-  :button{ text="Set", onclick=function()
-    app.fgColor = S1
-    end }
-  :button{ text="Set", onclick=function()
-    app.fgColor = S2
-    end }
-  :button{ text="Set", onclick=function()
-    app.fgColor = S3
-    end }
-  :button{ text="Set", onclick=function()
-    app.fgColor = currentColor
-    end }
-  :button{ text="Set", onclick=function()
-    app.fgColor = S5
-    end }
-  :button{ text="Set", onclick=function()
-    app.fgColor = S6
-    end }
-  :button{ text="Set", onclick=function()
-    app.fgColor = S7
-    end }
+  :shades{ id='sha', label='Shading',
+           colors={ S1, S2, S3, C, S5, S6, S7 },
+           onclick=function(ev) app.fgColor=ev.color end }
 
   -- LIGHTNESS
-  :label{ text="Lightness" }
-  :color{ color = L1 }
-  :color{ color = L2 }
-  :color{ color = L3 }
-  :color{ color = currentColor }
-  :color{ color = L5 }
-  :color{ color = L6 }
-  :color{ color = L7 }
-  :button{ text="Set", onclick=function()
-    app.fgColor = L1
-    end }
-  :button{ text="Set", onclick=function()
-    app.fgColor = L2
-    end }
-  :button{ text="Set", onclick=function()
-    app.fgColor = L3
-    end }
-  :button{ text="Set", onclick=function()
-    app.fgColor = currentColor
-    end }
-  :button{ text="Set", onclick=function()
-    app.fgColor = L5
-    end }
-  :button{ text="Set", onclick=function()
-    app.fgColor = L6
-    end }
-  :button{ text="Set", onclick=function()
-    app.fgColor = L7
-    end }
+  :shades{ id='lit', label='Lightness',
+           colors={ L1, L2, L3, C, L5, L6, L7 },
+           onclick=function(ev) app.fgColor=ev.color end }
 
   -- SATURATION
-  :label{ text="Saturation" }
-  :color{ color = C1 }
-  :color{ color = C2 }
-  :color{ color = C3 }
-  :color{ color = currentColor }
-  :color{ color = C5 }
-  :color{ color = C6 }
-  :color{ color = C7 }
-  :button{ text="Set", onclick=function()
-    app.fgColor = C1
-    end }
-  :button{ text="Set", onclick=function()
-    app.fgColor = C2
-    end }
-  :button{ text="Set", onclick=function()
-    app.fgColor = C3
-    end }
-  :button{ text="Set", onclick=function()
-    app.fgColor = currentColor
-    end }
-  :button{ text="Set", onclick=function()
-    app.fgColor = C5
-    end }
-  :button{ text="Set", onclick=function()
-    app.fgColor = C6
-    end }
-  :button{ text="Set", onclick=function()
-    app.fgColor = C7
-    end }
+  :shades{ id='sat', label='Saturation',
+           colors={ C1, C2, C3, C, C5, C6, C7 },
+           onclick=function(ev) app.fgColor=ev.color end }
 
   -- HUE
-  :label{ text="Hue" }
-  :color{ color = H1 }
-  :color{ color = H2 }
-  :color{ color = H3 }
-  :color{ color = currentColor }
-  :color{ color = H5 }
-  :color{ color = H6 }
-  :color{ color = H7 }
-  :button{ text="Set", onclick=function()
-    app.fgColor = H1
-    end }
-  :button{ text="Set", onclick=function()
-    app.fgColor = H2
-    end }
-  :button{ text="Set", onclick=function()
-    app.fgColor = H3
-    end }
-  :button{ text="Set", onclick=function()
-    app.fgColor = currentColor
-    end }
-  :button{ text="Set", onclick=function()
-    app.fgColor = H5
-    end }
-  :button{ text="Set", onclick=function()
-    app.fgColor = H6
-    end }
-  :button{ text="Set", onclick=function()
-    app.fgColor = H7
-    end }
+  :shades{ id='hue', label='Hue',
+           colors={ H1, H2, H3, C, H5, H6, H7 },
+           onclick=function(ev) app.fgColor=ev.color end }
 
-  dlg:show{ wait=false }
+  dlg:show{ wait=false, bounds=ColorShadingWindowBounds }
 
 end
 


### PR DESCRIPTION
Hi @dominickjohn, this PR is for the future, when Aseprite v1.2.17 is released in the future, you can merge this and the dialog will look something like this:

<img width="349" alt="Screen Shot 2019-12-17 at 14 25 15" src="https://user-images.githubusercontent.com/39654/71019455-16c19980-20d9-11ea-9182-63419f9cd31d.png">

It uses some new functions that will be available like `Dialog{ title, onclose }` and `Dialog:shades{}` to create a set of possible colors to pick.

Cheers!